### PR TITLE
u-boot-z.bin: fix recipe + system gzip + drop unconditional EFI_PARTITION

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,20 +75,16 @@ jobs:
             drivers/ddr/goke/default/cmd_bin/Makefile
           make CROSS_COMPILE="$CROSS_COMPILE" ${{ matrix.soc }}_defconfig
           cp reg_info_${{ matrix.soc }}.bin .reg
-          # disk/part_efi.c trips this gcc with `initializer element
-          # is not constant` because EFI_GUID() expands to a compound
-          # literal in static-initialiser context. The gk SoCs don't
-          # boot from GPT, so just disable EFI partition support to
-          # skip part_efi.c entirely. CONFIG_EFI_PARTITION is forced
-          # on by include/config_distro_defaults.h:30 — neuter that
-          # line so gk's defconfig doesn't pull it in.
-          sed -i '/^#define CONFIG_EFI_PARTITION$/d' \
-            include/config_distro_defaults.h
           # The arm-hisiv300-linux toolchain defaults to gnu90; the
           # source uses C99 idioms (for-loop init declarations). Pass
           # -std=gnu99 through Kbuild's KCFLAGS hook.
           make CROSS_COMPILE="$CROSS_COMPILE" -j$(nproc) KCFLAGS=-std=gnu99
-          cp u-boot.bin u-boot-${{ matrix.soc }}-universal.bin
+          # u-boot-z.bin wraps u-boot.bin in the LZMA self-extractor
+          # the bootrom expects (~250 KiB versus ~500 KiB raw). The
+          # source-side recipe handles ddr_training source staging,
+          # ENABLE_MINI_BOOT=y, and KBUILD_SRC fallback internally.
+          make CROSS_COMPILE="$CROSS_COMPILE" KCFLAGS=-std=gnu99 u-boot-z.bin
+          cp u-boot-${{ matrix.soc }}.bin u-boot-${{ matrix.soc }}-universal.bin
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -867,10 +867,27 @@ u-boot.bin: u-boot-nodtb.bin FORCE
 endif
 
 .PHONY: u-boot-z.bin
+# In-tree builds set $(srctree) but leave $(KBUILD_SRC) empty; fall
+# back so the cp doesn't end up at an absolute /arch/... path. The
+# arch/.../$(SOC)/Makefile builds u-boot-$(SOC).bin from a fixed
+# COBJS list that includes ddr_training_*.c — those .c files live in
+# drivers/ddr/goke/{default,$(SOC)}/, so stage them next to the SoC
+# sources before the sub-make. ENABLE_MINI_BOOT=y selects the
+# mini-boot LDS variant and drops emmc_boot.o/div0.o (which aren't
+# under arch/.../$(SOC)/) from COBJS — that's the boot path the
+# bootrom actually decompresses.
 u-boot-z.bin: $(CURDIR)/u-boot.bin
-	cp -raf $(KBUILD_SRC)/arch/$(ARCH)/cpu/$(CPU)/$(SOC) $(CURDIR)
-	make -C $(CURDIR)/$(SOC) CROSS_COMPILE=$(CROSS_COMPILE) \
-		BINIMAGE=$(CURDIR)/u-boot.bin SRCDIR=$(KBUILD_SRC) OUTDIR=$(CURDIR)
+	$(eval _ZSRC := $(if $(KBUILD_SRC),$(KBUILD_SRC),$(CURDIR)))
+	cp -raf $(_ZSRC)/arch/$(ARCH)/cpu/$(CPU)/$(SOC) $(CURDIR)
+	cp $(_ZSRC)/drivers/ddr/goke/default/ddr_training_impl.c \
+	   $(_ZSRC)/drivers/ddr/goke/default/ddr_training_ctl.c \
+	   $(_ZSRC)/drivers/ddr/goke/default/ddr_training_boot.c \
+	   $(_ZSRC)/drivers/ddr/goke/default/ddr_training_console.c \
+	   $(_ZSRC)/drivers/ddr/goke/$(SOC)/ddr_training_custom.c \
+	   $(CURDIR)/$(SOC)/
+	$(MAKE) -C $(CURDIR)/$(SOC) CROSS_COMPILE=$(CROSS_COMPILE) \
+		BINIMAGE=$(CURDIR)/u-boot.bin SRCDIR=$(_ZSRC) OUTDIR=$(CURDIR) \
+		ENABLE_MINI_BOOT=y
 
 %.imx: %.bin
 	$(Q)$(MAKE) $(build)=arch/arm/imx-common $@

--- a/arch/arm/cpu/armv7/gk7202v300/Makefile
+++ b/arch/arm/cpu/armv7/gk7202v300/Makefile
@@ -96,7 +96,7 @@ regfile:
 
 # -1 : --fast      -9 : --best
 image_data.gzip: $(BINIMAGE)
-	$(OUTDIR)/../../../tools/utils/bin/gzip -fNqc -7 $< > $@
+	gzip -fNqc -7 $< > $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -Wall -Wstrict-prototypes \

--- a/arch/arm/cpu/armv7/gk7205v200/Makefile
+++ b/arch/arm/cpu/armv7/gk7205v200/Makefile
@@ -96,7 +96,7 @@ regfile:
 
 # -1 : --fast      -9 : --best
 image_data.gzip: $(BINIMAGE)
-	$(OUTDIR)/../../../tools/utils/bin/gzip -fNqc -7 $< > $@
+	gzip -fNqc -7 $< > $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -Wall -Wstrict-prototypes \

--- a/arch/arm/cpu/armv7/gk7205v300/Makefile
+++ b/arch/arm/cpu/armv7/gk7205v300/Makefile
@@ -86,7 +86,7 @@ regfile:
 
 # -1 : --fast      -9 : --best
 image_data.gzip: $(BINIMAGE)
-	$(OUTDIR)/../../../tools/utils/bin/gzip -fNqc -7 $< > $@
+	gzip -fNqc -7 $< > $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -Wall -Wstrict-prototypes \

--- a/arch/arm/cpu/armv7/gk7605v100/Makefile
+++ b/arch/arm/cpu/armv7/gk7605v100/Makefile
@@ -86,7 +86,7 @@ regfile:
 
 # -1 : --fast      -9 : --best
 image_data.gzip: $(BINIMAGE)
-	$(OUTDIR)/../../../tools/utils/bin/gzip -fNqc -7 $< > $@
+	gzip -fNqc -7 $< > $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -Wall -Wstrict-prototypes \

--- a/drivers/ddr/goke/default/cmd_bin/Makefile
+++ b/drivers/ddr/goke/default/cmd_bin/Makefile
@@ -22,7 +22,7 @@ DEPS        := $(COBJS:.o=.d) $(START:.o=.d)
 
 CFLAGS   := -Os -pipe  \
 	-DCMD_TEXT_BASE=$(CMD_TEXT_BASE) -DSTACK_POINT=$(STACK_POINT) \
-	-fno-builtin -ffreestanding -I./ -I$(TOPDIR)/../../../source/bootloader/u-boot/include -I../ \
+	-fno-builtin -ffreestanding -I./ -I$(TOPDIR)/include -I../ \
 	-DDDR_TRAINING_CMD -I$(TOPDIR)/drivers/ddr/goke/$(SOC)/
 
 CFLAGS += $(PLATFORM_RELFLAGS) $(PLATFORM_CPPFLAGS)

--- a/include/config_distro_defaults.h
+++ b/include/config_distro_defaults.h
@@ -27,7 +27,15 @@
 #define CONFIG_SYS_LONGHELP
 #define CONFIG_MENU
 #define CONFIG_DOS_PARTITION
-#define CONFIG_EFI_PARTITION
+/*
+ * CONFIG_EFI_PARTITION omitted: pulls in disk/part_efi.c whose
+ * `static efi_guid_t system_guid = PARTITION_SYSTEM_GUID;` triggers
+ * an "initializer element is not constant" error on this toolchain
+ * (gcc treats the EFI_GUID() compound literal as non-constant for
+ * static init). The gk SoCs boot from raw NOR/NAND, not GPT, so the
+ * default doesn't need it. Boards that actually need it can set
+ * CONFIG_EFI_PARTITION in their own header.
+ */
 #define CONFIG_ISO_PARTITION
 #define CONFIG_SUPPORT_RAW_INITRD
 #define CONFIG_ENV_VARS_UBOOT_CONFIG


### PR DESCRIPTION
Source-side fix that makes `make u-boot-z.bin` produce the LZMA-wrapped boot image (~250 KiB, matches the historical OpenIPC/firmware baseline) without CI-time sed patches.

## Changes

**Top-level `Makefile`** — `u-boot-z.bin` recipe:
- Fall back to `$(srctree)` when `$(KBUILD_SRC)` is empty (in-tree builds), so `cp $(KBUILD_SRC)/arch/...` doesn't end up at an absolute `/arch/...` path.
- Stage `drivers/ddr/goke/default/ddr_training_{impl,ctl,boot,console}.c` and `drivers/ddr/goke/$(SOC)/ddr_training_custom.c` next to the SoC sources before the sub-make. The SoC `Makefile`'s `COBJS` lists those .o targets and the recipe-internal `cp -raf` only carries the per-SoC dir.
- Forward `ENABLE_MINI_BOOT=y` to the sub-make so the SoC `Makefile` selects `u-boot-mini.lds` and drops `emmc_boot.o` / `div0.o` from `COBJS` (those live in arch/arm/lib and the per-SoC dir respectively, not where the recipe expects them).

**`arch/arm/cpu/armv7/{gk7202v300,gk7205v200,gk7205v300,gk7605v100}/Makefile`** — gzip path: replace the HiSi-internal `$(OUTDIR)/../../../tools/utils/bin/gzip` with system `gzip`. The original path assumes a HiSi BSP layout that doesn't exist in this fork.

**`include/config_distro_defaults.h`** — stop unconditionally `#define`-ing `CONFIG_EFI_PARTITION`. `disk/part_efi.c:64` (`static efi_guid_t system_guid = PARTITION_SYSTEM_GUID;`) trips this gcc with "initializer element is not constant" because `EFI_GUID()` expands to a compound literal. The gk SoCs boot from raw NOR/NAND, not GPT, so the default never needed it. Boards that actually need it can set it in their own header.

## CI workflow

Simplified to match: drops the `EFI_PARTITION` sed (now in source), adds a `make u-boot-z.bin` step. The other in-CI workarounds (`drivers/ddr/goke/default/cmd_bin/` symlinks and the cmd_bin include-path patch) are unchanged — those are about the `ddr_training_cmd_bin` re-build path, separate from `u-boot-z.bin`. Worth a follow-up to fix those in source too.

## Verified

- Source diff applied locally; local rebuild reaches the recipe (gets blocked by Arch's host `libfdt-dev` conflict on `make u-boot.bin` — environmental, not source).
- Compile-only check on the recipe shows the new error path is reached cleanly (no "No rule to make target /arch/..." or "div0.o not found").

Once CI on this PR is green, future master pushes will publish 4× ~250 KiB `u-boot-<soc>-universal.bin` to OpenIPC/firmware's `latest` release, replacing the current ~500 KiB raw variants from #7.