### PR TITLE
TEST: verify qemu#85 fix catches system-gzip regression (DO NOT MERGE)

### DIFF
--- a/arch/arm/cpu/armv7/gk7205v300/Makefile
+++ b/arch/arm/cpu/armv7/gk7205v300/Makefile
@@ -86,7 +86,7 @@ regfile:
 
 # -1 : --fast      -9 : --best
 image_data.gzip: $(BINIMAGE)
-	./gzip -fNqc -7 $< > $@
+	gzip -fNqc -7 $< > $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -Wall -Wstrict-prototypes \


### PR DESCRIPTION
## Test scaffold — do not merge

Reverts `arch/arm/cpu/armv7/gk7205v300/Makefile` to use system
`gzip` (32 KiB window), reproducing the May 8 hardware regression
fixed by #14. The other 3 SoCs are unchanged as controls.

## Expected outcome

- `qemu_smoke (gk7205v300)` **FAILS** with "Uncompress Fail!"
  → the qemu#85 fix is correctly enforcing the 8 KiB window.
- `qemu_smoke (gk7202v300, gk7205v200, gk7605v100)` all **PASS**
  → the gate is targeted, not over-strict.

## Rollback

After verification, this branch and PR get closed/deleted; no
merge to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)