### PR TITLE
TEST: verify qemu#88 catches system-gzip regression (DO NOT MERGE)

### DIFF
--- a/arch/arm/cpu/armv7/gk7205v300/Makefile
+++ b/arch/arm/cpu/armv7/gk7205v300/Makefile
@@ -86,7 +86,7 @@ regfile:
 
 # -1 : --fast      -9 : --best
 image_data.gzip: $(BINIMAGE)
-	./gzip -fNqc -7 $< > $@
+	gzip -fNqc -7 $< > $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) -Wall -Wstrict-prototypes \


### PR DESCRIPTION
Re-runs the test from PR #15 now that qemu#85 is properly fixed by qemu-hisilicon#88 (chunked-inflate loop so the windowBits cap actually enforces).

Expected: `qemu_smoke (gk7205v300)` FAILS with "Uncompress Fail!".
Other 3 SoCs pass as controls.

Closes after verification. Do not merge.